### PR TITLE
add error message

### DIFF
--- a/src/external_registration.cpp
+++ b/src/external_registration.cpp
@@ -38,10 +38,12 @@ int main(int argc, char** argv)
 
   if ( argc > 1 )
   {
+    std::string network_interface = "eth0";
+    if ( argc > 2 ) network_interface = argv[2];
     std::cout << BOLDYELLOW << "using ip address: "
-              << BOLDCYAN << argv[1] << RESETCOLOR << std::endl;
+              << BOLDCYAN << argv[1] << " @ " << network_interface << RESETCOLOR << std::endl;
     bs->init();
-    bs->setMasterURI( "http://"+std::string(argv[1])+":11311");
+    bs->setMasterURINet( "http://"+std::string(argv[1])+":11311", network_interface);
   }
   else
   {

--- a/src/ros_env.hpp
+++ b/src/ros_env.hpp
@@ -47,8 +47,17 @@ static std::string getROSIP(std::string network_interface)
 {
   if (network_interface.empty())
     network_interface = "eth0";
+
   typedef std::map< std::string, std::vector<std::string> > Map_IP;
-  static const std::string ip = static_cast<Map_IP>(qi::os::hostIPAddrs())[network_interface][0];
+  Map_IP map_ip = static_cast<Map_IP>(qi::os::hostIPAddrs());
+  if ( map_ip.find(network_interface) == map_ip.end() ) {
+    std::cerr << "Could not find network interface named " << network_interface << ", pssible interfaces are ... ";
+    for (Map_IP::iterator it=map_ip.begin(); it!=map_ip.end(); ++it) std::cerr << it->first <<  " ";
+    std::cerr << std::endl;
+    exit(1);
+  }
+
+  static const std::string ip = map_ip[network_interface][0];
   return ip;
 }
 


### PR DESCRIPTION
I'm not always use eth0 to connect the robot, using wireless or vpn

- main:  support 2nd argument as network interface
- ros_env.hpp write error message when network interface is not found